### PR TITLE
Add acme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM portainer/portainer:1.19.2 AS base
 
-FROM alpine:latest
+FROM neilpang/acme.sh:latest
 # TODO: Pick either CURL or HTTPie and use that consistently. 
 RUN apk add --no-cache bash python py-pip ca-certificates curl mosquitto-clients
 RUN pip install --upgrade pip

--- a/mqtt-scripts/acme-helpers.sh
+++ b/mqtt-scripts/acme-helpers.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# TODO: Figure out how to get this sourced automatically. 
+source ${lib_path}create-secret.sh
+
+# $1: The acme_env file
+    # acme_env file should contain ACME_FLAGS, all other vars are optional. 
+    # It should support any .env vars that acme.sh supports. 
+    # ACME_FLAGS="--dns dns_duckdns"
+    # ACME_DOMAIN="technocore.duckdns.org"
+    # DuckDNS_Token="YOUR-ASSIGNED-TOKEN"
+# $2: 'issue' if the cert should be created, 'renew' otherwise. 
+function update_duckdns_tls() 
+{
+    set -a
+    eval "$1"
+    set +a
+    
+    hostname_trimmed=$(echo ${DOCKER_HOSTNAME} | cut -d"." -f 1)
+    acme.sh --dnssleep 30 --test --$2 -d $ACME_DOMAIN $ACME_FLAGS # $ACME_CHALLENGE_ALIAS 
+
+    # Update secrets
+    create_secret nginx cert_bundle "$(cat /acme.sh/${ACME_DOMAIN}/fullchain.cer)"
+    create_secret nginx key "$(cat /acme.sh/${ACME_DOMAIN}/${ACME_DOMAIN}.key)"
+
+    # Update DuckDNS entry with the internal IP address. 
+    ip=$(ping -c 1 ${hostname_trimmed} | awk -F '[()]' '/PING/{print $2}')
+    echo url="https://www.duckdns.org/update?domains=${ACME_DOMAIN}&token=${DuckDNS_Token}&ip=${ip}" | curl -K -
+}

--- a/mqtt-scripts/acme-helpers.sh
+++ b/mqtt-scripts/acme-helpers.sh
@@ -17,7 +17,7 @@ function update_duckdns_tls()
     set +a
     
     hostname_trimmed=$(echo ${DOCKER_HOSTNAME} | cut -d"." -f 1)
-    if ! acme.sh --dnssleep 30 --test --$2 -d $ACME_DOMAIN $ACME_FLAGS # $ACME_CHALLENGE_ALIAS 
+    if ! acme.sh --dnssleep 30 $acme_flags --$2 -d $ACME_DOMAIN $ACME_FLAGS # $ACME_CHALLENGE_ALIAS 
     then
         return 1
     fi

--- a/mqtt-scripts/acme-helpers.sh
+++ b/mqtt-scripts/acme-helpers.sh
@@ -28,5 +28,7 @@ function update_duckdns_tls()
 
     # Update DuckDNS entry with the internal IP address. 
     ip=$(ping -c 1 ${hostname_trimmed} | awk -F '[()]' '/PING/{print $2}')
+    # How to silence curl: https://unix.stackexchange.com/questions/196549/hide-curl-output
+    echo url="https://www.duckdns.org/update?domains=${ACME_DOMAIN}&token=${DuckDNS_Token}&ip=${ip}" | curl -s -K - > /dev/null
     return 0
 }

--- a/mqtt-scripts/acme-helpers.sh
+++ b/mqtt-scripts/acme-helpers.sh
@@ -17,7 +17,10 @@ function update_duckdns_tls()
     set +a
     
     hostname_trimmed=$(echo ${DOCKER_HOSTNAME} | cut -d"." -f 1)
-    acme.sh --dnssleep 30 --test --$2 -d $ACME_DOMAIN $ACME_FLAGS # $ACME_CHALLENGE_ALIAS 
+    if ! acme.sh --dnssleep 30 --test --$2 -d $ACME_DOMAIN $ACME_FLAGS # $ACME_CHALLENGE_ALIAS 
+    then
+        return 1
+    fi
 
     # Update secrets
     create_secret nginx cert_bundle "$(cat /acme.sh/${ACME_DOMAIN}/fullchain.cer)"
@@ -25,5 +28,5 @@ function update_duckdns_tls()
 
     # Update DuckDNS entry with the internal IP address. 
     ip=$(ping -c 1 ${hostname_trimmed} | awk -F '[()]' '/PING/{print $2}')
-    echo url="https://www.duckdns.org/update?domains=${ACME_DOMAIN}&token=${DuckDNS_Token}&ip=${ip}" | curl -K -
+    return 0
 }

--- a/mqtt-scripts/acme-helpers.sh
+++ b/mqtt-scripts/acme-helpers.sh
@@ -19,6 +19,9 @@ function update_duckdns_tls()
     hostname_trimmed=$(echo ${DOCKER_HOSTNAME} | cut -d"." -f 1)
     if ! acme.sh --dnssleep 30 $acme_flags --$2 -d $ACME_DOMAIN $ACME_FLAGS # $ACME_CHALLENGE_ALIAS 
     then
+        # DuckDNS's TTL is 1 minute. 
+        echo "Waiting 30 seconds to allow caches to clear before retrying."
+        sleep 30
         return 1
     fi
 

--- a/mqtt-scripts/create-secret.sh
+++ b/mqtt-scripts/create-secret.sh
@@ -9,10 +9,11 @@ function create_secret()
     mount_point=$2
     secret_name=${stack_name}_${service_name}_${mount_point}
     secret=$3
-    echo -e "$secret" | docker secret create ${secret_name}.temp -
-    docker service update --detach=true --secret-rm ${secret_name} --secret-add source=${secret_name}.temp,target=${mount_point} ${stackname}_${service_name}
-    docker secret rm ${secret_name}
-    echo -e "$secret" | docker secret create ${secret_name} - 
-    docker service update --detach=true --secret-rm ${secret_name}.temp --secret-add source=${secret_name},target=${mount_point} ${stackname}_${service_name} 
-    docker secret rm ${secret_name}.temp
+    echo "Updating secret ${secret_name}"
+    echo -e "$secret" | docker secret create ${secret_name}.temp - > /dev/null
+    docker service update --detach=true --secret-rm ${secret_name} --secret-add source=${secret_name}.temp,target=${mount_point} ${stackname}_${service_name} > /dev/null
+    docker secret rm ${secret_name} > /dev/null
+    echo -e "$secret" | docker secret create ${secret_name} - > /dev/null
+    docker service update --detach=true --secret-rm ${secret_name}.temp --secret-add source=${secret_name},target=${mount_point} ${stackname}_${service_name} > /dev/null
+    docker secret rm ${secret_name}.temp > /dev/null
 }

--- a/mqtt-scripts/create-secret.sh
+++ b/mqtt-scripts/create-secret.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# $1: The service this secret is for
+# $2: Mount point for the secret. mqtt_username is an example. 
+# $3: The secret to store. 
+function create_secret()
+{
+    service_name=$1
+    mount_point=$2
+    secret_name=${stack_name}_${service_name}_${mount_point}
+    secret=$3
+    echo -e "$secret" | docker secret create ${secret_name}.temp -
+    docker service update --detach=true --secret-rm ${secret_name} --secret-add source=${secret_name}.temp,target=${mount_point} ${stackname}_${service_name}
+    docker secret rm ${secret_name}
+    echo -e "$secret" | docker secret create ${secret_name} - 
+    docker service update --detach=true --secret-rm ${secret_name}.temp --secret-add source=${secret_name},target=${mount_point} ${stackname}_${service_name} 
+    docker secret rm ${secret_name}.temp
+}

--- a/mqtt-scripts/create-secret.sub
+++ b/mqtt-scripts/create-secret.sub
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source ${lib_path}create-secret.sh
+
 # $1: Topic to subscribe to
 # $2+: Command to run upon message reception.
 function subscribe()
@@ -29,7 +31,7 @@ function subscribe()
     echo "If you see this, something has gone wrong."
 }
 
-function create_secret()
+function create_secret_from_mqtt()
 {
     cmd=${topic/portainer/docker}
     cmd=$(echo "$cmd" | tr "/" " " ) 
@@ -60,12 +62,7 @@ function create_secret()
     #echo "Swarm_Service_name: $swarm_service_name"
     #echo "full_service_name: $full_service_name"
 
-    echo -e "$message" | docker secret create ${secret_name}.temp -
-    docker service update --detach=true --secret-rm ${secret_name} --secret-add source=${secret_name}.temp,target=${mount_point} ${stackname}_${swarm_service_name}
-    docker secret rm ${secret_name}
-    echo -e "$message" | docker secret create ${secret_name} - 
-    docker service update --detach=true --secret-rm ${secret_name}.temp --secret-add source=${secret_name},target=${mount_point} ${stackname}_${swarm_service_name} 
-    docker secret rm ${secret_name}.temp
+    create_secret "$service_name" "$mount_point" "$message"
 }
 
-subscribe portainer/secret/create/# create_secret
+subscribe portainer/secret/create/# create_secret_from_mqtt

--- a/mqtt-scripts/gen-tls.sh
+++ b/mqtt-scripts/gen-tls.sh
@@ -3,6 +3,7 @@
 source ${lib_path}acme-helpers.sh
 source ${lib_path}create-secret.sh
 
+# TODO: Write a better explanation of what is going on here. 
 # TODO: Consider having these optionally passed in via command line or ENV instead of forcing from CMD. 
 #       It would allow me to not have to input the creds every time. Nice. GOOD FIRST TICKET
 #       Should also investigate why if failed after running the first time, it has to be restarted to work. 
@@ -27,7 +28,8 @@ END
 )
 if update_duckdns_tls "$acme_secret" issue 
 then
-create_secret portainer acme_env "$acme_secret"
+    create_secret portainer acme_env "$acme_secret"
+    create_secret home_assistant domain "$domain.duckdns.org"
 else
     echo "Could not issue TLS cert."
     exit 1

--- a/mqtt-scripts/gen-tls.sh
+++ b/mqtt-scripts/gen-tls.sh
@@ -3,23 +3,26 @@
 source ${lib_path}acme-helpers.sh
 source ${lib_path}create-secret.sh
 
-# TODO: Write a better explanation of what is going on here. 
 # TODO: Consider having these optionally passed in via command line or ENV instead of forcing from CMD. 
 #       It would allow me to not have to input the creds every time. Nice. GOOD FIRST TICKET
 #       Should also investigate why if failed after running the first time, it has to be restarted to work. 
 # https://stackoverflow.com/questions/3980668/how-to-get-a-password-from-a-shell-script-without-echoing
-read -p "DuckDNS Sub-domain - example: technocore.duckdns.org should enter \"technocore\" : " domain
+echo -e "\n\n\n"
+echo -e "A DuckDNS domain and token is needed to setup LetsEncrypt (secures all communication)."
+echo -e "LetsEncrypt is not required, but does produce the best results. Run the installer with the --dev flag to use a self signed cert."
+echo -e "1) Visit https://www.duckdns.org/ and login using an account you already have (hopefully)."
+echo -e "2) Create a duckdns sub-domain."
+echo -e "3) Enter your sub-domain and token in the following prompts."
+echo -e "   Example: If your domain is technocore.duckdns.org, you should enter \"technocore\" "
+echo -e "   Reminder: In most terminals you have to use ctrl+shift+v to paste (alternatively, right click) and you won't see the result in the token field."
+read -p "DuckDNS Sub-domain: " domain
 read -s -p "DuckDNS Token: " token
 echo ""
 
 # acme_env file should contain ACME_FLAGS, all other vars are optional. 
 # It should support any .env vars that acme.sh supports. 
-# ACME_FLAGS="--dns dns_duckdns"
-# ACME_CHALLENGE_ALIAS="--challenge-alias technocore.duckdns.org"
-# DuckDNS_Token="YOUR-ASSIGNED-TOKEN"
-
-# https://stackoverflow.com/questions/23929235/multi-line-string-with-extra-space-preserved-indentation
 # TODO: Turn into snippet
+# https://stackoverflow.com/questions/23929235/multi-line-string-with-extra-space-preserved-indentation
 acme_secret=$(cat <<-END
     ACME_FLAGS="--dns dns_duckdns"
     ACME_DOMAIN="${domain}.duckdns.org"

--- a/mqtt-scripts/gen-tls.sh
+++ b/mqtt-scripts/gen-tls.sh
@@ -5,6 +5,7 @@ source ${lib_path}create-secret.sh
 
 # TODO: Consider having these optionally passed in via command line or ENV instead of forcing from CMD. 
 #       It would allow me to not have to input the creds every time. Nice. GOOD FIRST TICKET
+#       Should also investigate why if failed after running the first time, it has to be restarted to work. 
 # https://stackoverflow.com/questions/3980668/how-to-get-a-password-from-a-shell-script-without-echoing
 read -p "DuckDNS Sub-domain - example: technocore.duckdns.org should enter \"technocore\" : " domain
 read -s -p "DuckDNS Token: " token
@@ -24,6 +25,11 @@ acme_secret=$(cat <<-END
     DuckDNS_Token="$token"
 END
 )
-update_duckdns_tls "$acme_secret" issue 
+if update_duckdns_tls "$acme_secret" issue 
+then
 create_secret portainer acme_env "$acme_secret"
+else
+    echo "Could not issue TLS cert."
+    exit 1
+fi
 exit 0

--- a/mqtt-scripts/gen-tls.sh
+++ b/mqtt-scripts/gen-tls.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# TODO: Figure out how to auto include this.
+source ${lib_path}acme-helpers.sh
+source ${lib_path}create-secret.sh
+
+# https://stackoverflow.com/questions/3980668/how-to-get-a-password-from-a-shell-script-without-echoing
+read -p "DuckDNS Sub-domain - example: technocore.duckdns.org should enter \"technocore\" : " domain
+read -s -p "DuckDNS Token: " token
+echo ""
+
+# acme_env file should contain ACME_FLAGS, all other vars are optional. 
+# It should support any .env vars that acme.sh supports. 
+# ACME_FLAGS="--dns dns_duckdns"
+# ACME_CHALLENGE_ALIAS="--challenge-alias technocore.duckdns.org"
+# DuckDNS_Token="YOUR-ASSIGNED-TOKEN"
+
+# https://stackoverflow.com/questions/23929235/multi-line-string-with-extra-space-preserved-indentation
+# TODO: Turn into snippet
+acme_secret=$(cat <<-END
+    ACME_FLAGS="--dns dns_duckdns"
+    ACME_DOMAIN="${domain}.duckdns.org"
+    DuckDNS_Token="$token"
+END
+)
+update_duckdns_tls "$acme_secret" issue 
+create_secret portainer acme_env "$acme_secret"
+# This prevents the process from finishing before the container has shutdown.
+sleep 600

--- a/mqtt-scripts/gen-tls.sh
+++ b/mqtt-scripts/gen-tls.sh
@@ -3,6 +3,8 @@
 source ${lib_path}acme-helpers.sh
 source ${lib_path}create-secret.sh
 
+# TODO: Consider having these optionally passed in via command line or ENV instead of forcing from CMD. 
+#       It would allow me to not have to input the creds every time. Nice. GOOD FIRST TICKET
 # https://stackoverflow.com/questions/3980668/how-to-get-a-password-from-a-shell-script-without-echoing
 read -p "DuckDNS Sub-domain - example: technocore.duckdns.org should enter \"technocore\" : " domain
 read -s -p "DuckDNS Token: " token
@@ -24,5 +26,4 @@ END
 )
 update_duckdns_tls "$acme_secret" issue 
 create_secret portainer acme_env "$acme_secret"
-# This prevents the process from finishing before the container has shutdown.
-sleep 600
+exit 0

--- a/mqtt-scripts/get-domain.sh
+++ b/mqtt-scripts/get-domain.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-if [ -f /run/secrets/acme_env ]; then
-    eval "$(cat /run/secrets/acme_env)"
-    echo "$ACME_DOMAIN"
-    exit 0
+if cat /run/secrets/acme_env | grep "Not yet set." &> /dev/null
+then
+    echo "acme_env has not been set."
+    exit 1
 fi
 
-exit 1
+eval "$(cat /run/secrets/acme_env)" &> /dev/null
+# echo caused non-ascii chars to be printed."
+printf "$ACME_DOMAIN"
+exit 0

--- a/mqtt-scripts/get-domain.sh
+++ b/mqtt-scripts/get-domain.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [ -f /run/secrets/acme_env ]; then
+    eval "$(cat /run/secrets/acme_env)"
+    echo "$ACME_DOMAIN"
+    exit 0
+fi
+
+exit 1

--- a/mqtt-scripts/init.sh
+++ b/mqtt-scripts/init.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-for file in /usr/share/mqtt-scripts/*.sub; do
+lib_path=/usr/share/mqtt-scripts/
+
+for file in ${lib_path}*.sub; do
     # TODO: Make this ignore .pub files? Or maybe I just use *.sub.
     if [ "$file" == "/usr/share/mqtt-scripts/init.sh" ] ; then
         continue;

--- a/mqtt-scripts/renew-tls.sub
+++ b/mqtt-scripts/renew-tls.sub
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# TODO: Figure out how to get this sourced automatically. 
+source ${lib_path}acme-helpers.sh
+
+while true
+do
+    if ! $(cat /run/secrets/acme_env | grep "Not yet set." > /dev/null) ; then
+        update_duckdns_tls "$(cat /run/secrets/acme_env)" renew 
+    fi
+    sleep 1d
+done

--- a/shell-migrations/20180826175057-create-and-save-users-migrate.sh
+++ b/shell-migrations/20180826175057-create-and-save-users-migrate.sh
@@ -22,6 +22,3 @@ sleep 10
 
 create_mqtt_user home_assistant "home_assistant"
 create_mqtt_user node_red "node_red"
-create_mqtt_user platformio "platformio"
-docker rm -f pio
-#docker service update --force $stackname platformio


### PR DESCRIPTION
### Added [acme.sh ](https://github.com/Neilpang/acme.sh)
This allows for automating the LetsEncrypt verification process. To support this, I created 3 scripts:
- gen-tls.sh
    Has the user input their DuckDNS domain and token, then generates a TLS cert and saves it as nginx's cert. 
- get-domain.sh
    Returns the domain acme.sh is configured for. This is needed in order to present the URL during install. 
- renew-tls.sub 
    Renews the certificate every day. If cert expiration is less than 30 days out, it'll actually renew. 

The way acme.sh works is that it pretty much always takes the credentials as env vars. So I store those, and the other settings needed for a specific provider in the portainer_acme_env secret. The format is your usual
```KEY=VALUE```
If you want to create your own acme_env, you'll just need to include the vars needed for your plugin, along with ACME_FLAGS and ACME_DOMAIN. Example:
```
ACME_FLAGS="--dns dns_duckdns"
ACME_DOMAIN="technocore.duckdns.org"
DuckDNS_Token="YOUR-SECRET-TOKEN-HERE"
```

Checkout [Neilpang/acme.sh](https://github.com/Neilpang/acme.sh) for more information on acme.sh. 

### Other changes
Refactored create_secret so that it could be used by get-tls.sh.
Removed PlatformIO.

Eventually, I think it makes sense to split acme off into it's own service. See https://github.com/SciFiFarms/TechnoCore-Portainer/issues/3